### PR TITLE
数值单位显示/灵宠一键放生品质选择

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+package.json
 node_modules
 dist
 dist-ssr

--- a/package.json
+++ b/package.json
@@ -28,5 +28,6 @@
     "unplugin-auto-import": "^19.1.0",
     "unplugin-vue-components": "^28.1.0",
     "vite": "^6.1.0"
-  }
+  },
+  "packageManager": "pnpm@10.2.0+sha512.0d27364e0139c6aadeed65ada153135e0ca96c8da42123bd50047f961339dc7a758fc2e944b428f52be570d1bd3372455c1c65fa2e7aa0bfbf931190f9552001"
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@ import { NIcon, darkTheme } from 'naive-ui'
 import { BookOutlined, ExperimentOutlined, CompassOutlined, TrophyOutlined, SettingOutlined, MedicineBoxOutlined, GiftOutlined, HomeOutlined, SmileOutlined } from '@ant-design/icons-vue'
 import { Moon, Sunny, Flash } from '@vicons/ionicons5'
 import { getRealmName } from './plugins/realm'
+import { formatNumberToChineseUnit } from './plugins/utils'
 
 const router = useRouter()
 const route = useRoute()
@@ -183,16 +184,16 @@ const handleMenuClick = (key) => {
                       {{ getRealmName(playerStore.level) }}
                     </n-descriptions-item>
                     <n-descriptions-item label="修为">
-                      {{ playerStore.cultivation }} / {{ playerStore.maxCultivation }}
+                      {{ formatNumberToChineseUnit(playerStore.cultivation) }} / {{ formatNumberToChineseUnit(playerStore.maxCultivation) }}
                     </n-descriptions-item>
                     <n-descriptions-item label="灵力">
-                      {{ playerStore.spirit.toFixed(2) }}
+                      {{ formatNumberToChineseUnit(playerStore.spirit) }}
                     </n-descriptions-item>
                     <n-descriptions-item label="灵石">
-                      {{ playerStore.spiritStones }}
+                      {{ formatNumberToChineseUnit(playerStore.spiritStones) }}
                     </n-descriptions-item>
                     <n-descriptions-item label="强化石">
-                      {{ playerStore.reinforceStones }}
+                      {{ formatNumberToChineseUnit(playerStore.reinforceStones) }}
                     </n-descriptions-item>
                   </n-descriptions>
                   <n-progress

--- a/src/plugins/utils.js
+++ b/src/plugins/utils.js
@@ -1,0 +1,38 @@
+// 将数字格式化为中文单位（显示相邻两个单位）
+export const formatNumberToChineseUnit = (number) => {
+    number = number > 0 ? Math.floor(number) : 0;
+    const units = ['', '万', '亿', '兆', '京', '垓', '秭', '穰', '沟', '涧', '正', '载', '极'];
+    
+    // 处理小于1万的数字
+    if (number < 10000) {
+        return number.toString();
+    }
+    
+    let num = number;
+    let unitIndex = 0;
+    
+    // 找到最大单位
+    while (num >= 10000 && unitIndex < units.length - 1) {
+        num = Math.floor(num / 10000);
+        unitIndex++;
+    }
+    
+    // 获取高位数值
+    const highNum = num;
+    
+    // 获取低位数值（前一个单位的数字）
+    const lowNum = Math.floor((number % (10000 ** unitIndex)) / (10000 ** (unitIndex - 1)));
+    
+    // 如果是万以下的数字，直接返回
+    if (unitIndex === 0) {
+        return number.toString();
+    }
+    
+    // 如果只有一个单位，只显示一个
+    if (unitIndex === 1) {
+        return highNum + units[unitIndex];
+    }
+    
+    // 显示两个相邻单位
+    return highNum + units[unitIndex] + (lowNum > 0 ? lowNum.toString().padStart(4, '0') + units[unitIndex - 1] : '');
+};

--- a/src/views/Alchemy.vue
+++ b/src/views/Alchemy.vue
@@ -4,6 +4,7 @@ import { usePlayerStore } from '../stores/player'
 import { pillRecipes, pillGrades, pillTypes, calculatePillEffect } from '../plugins/pills'
 import { herbs } from '../plugins/herbs'
 import LogPanel from '../components/LogPanel.vue'
+import { formatNumberToChineseUnit } from '../plugins/utils'
 
 const playerStore = usePlayerStore()
 const logRef = ref(null)
@@ -33,7 +34,7 @@ const checkMaterials = (recipe) => {
 // 获取材料状态文本
 const getMaterialStatus = (material) => {
     const count = playerStore.herbs.filter(h => h.id === material.herb).length
-    return `${count}/${material.count}`
+    return `${formatNumberToChineseUnit(count)}/${formatNumberToChineseUnit(material.count)}`
 }
 
 // 获取灵草名称
@@ -45,7 +46,7 @@ const getHerbName = (herbId) => {
 // 计算当前效果
 const currentEffect = computed(() => {
     if (!selectedRecipe.value) return null
-    return calculatePillEffect(selectedRecipe.value, playerStore.level)
+    return formatNumberToChineseUnit(calculatePillEffect(selectedRecipe.value, playerStore.level))
 })
 
 // 炼制丹药

--- a/src/views/Cultivation.vue
+++ b/src/views/Cultivation.vue
@@ -1,9 +1,10 @@
 <script setup>
 import { usePlayerStore } from '../stores/player'
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted, computed } from 'vue'
 import { NIcon } from 'naive-ui'
 import { BookOutline } from '@vicons/ionicons5'
 import LogPanel from '../components/LogPanel.vue'
+import { formatNumberToChineseUnit } from '../plugins/utils'
 
 const playerStore = usePlayerStore()
 const logRef = ref(null)
@@ -205,7 +206,7 @@ onUnmounted(() => {
                     @click="cultivate"
                     :disabled="playerStore.spirit < cultivationCost"
                 >
-                    打坐修炼 (消耗 {{ cultivationCost }} 灵力)
+                    打坐修炼 (消耗 {{ formatNumberToChineseUnit(cultivationCost) }} 灵力)
                 </n-button>
 
                 <n-button
@@ -234,13 +235,13 @@ onUnmounted(() => {
                 <n-collapse-item title="修炼详情" name="details">
                     <n-descriptions bordered>
                         <n-descriptions-item label="灵力获取速率">
-                            {{ baseGainRate * playerStore.spiritRate }} / 秒
+                            {{ formatNumberToChineseUnit(baseGainRate * playerStore.spiritRate) }} / 秒
                         </n-descriptions-item>
                         <n-descriptions-item label="修炼效率">
-                            {{ cultivationGain }} 修为 / 次
+                            {{ formatNumberToChineseUnit(cultivationGain) }} 修为 / 次
                         </n-descriptions-item>
                         <n-descriptions-item label="突破所需修为">
-                            {{ playerStore.maxCultivation }}
+                            {{ formatNumberToChineseUnit(playerStore.maxCultivation) }}
                         </n-descriptions-item>
                     </n-descriptions>
                 </n-collapse-item>

--- a/src/views/Dungeon.vue
+++ b/src/views/Dungeon.vue
@@ -6,6 +6,7 @@ import { getRandomOptions } from '../plugins/dungeon'
 import dungeonBuffs from '../plugins/dungeonBuffs'
 import { useMessage } from 'naive-ui'
 import LogPanel from '../components/LogPanel.vue'
+import { formatNumberToChineseUnit } from '../plugins/utils'
 
 const playerStore = usePlayerStore()
 const message = useMessage()
@@ -264,17 +265,17 @@ const generateRewards = () => {
                         <!-- 玩家属性 -->
                         <n-descriptions bordered :title="`${dungeonState.combatManager.player.name}的属性`" :span="2">
                             <n-descriptions-item label="生命值">
-                                {{ dungeonState.combatManager.player.currentHealth.toFixed(1) }} /
-                                {{ dungeonState.combatManager.player.stats.maxHealth.toFixed(1) }}
+                                {{ formatNumberToChineseUnit(dungeonState.combatManager.player.currentHealth) }} /
+                                {{ formatNumberToChineseUnit(dungeonState.combatManager.player.stats.maxHealth) }}
                             </n-descriptions-item>
                             <n-descriptions-item label="攻击力">
-                                {{ dungeonState.combatManager.player.stats.damage.toFixed(1) }}
+                                {{ formatNumberToChineseUnit(dungeonState.combatManager.player.stats.damage) }}
                             </n-descriptions-item>
                             <n-descriptions-item label="防御力">
-                                {{ dungeonState.combatManager.player.stats.defense.toFixed(1) }}
+                                {{ formatNumberToChineseUnit(dungeonState.combatManager.player.stats.defense) }}
                             </n-descriptions-item>
                             <n-descriptions-item label="速度">
-                                {{ dungeonState.combatManager.player.stats.speed.toFixed(1) }}
+                                {{ formatNumberToChineseUnit(dungeonState.combatManager.player.stats.speed) }}
                             </n-descriptions-item>
                         </n-descriptions>
                         <n-collapse style="margin-top: 16px">
@@ -351,17 +352,17 @@ const generateRewards = () => {
                         <!-- 敌人属性 -->
                         <n-descriptions bordered :title="`${dungeonState.combatManager.enemy.name}的属性`" :span="2" style="margin-top: 16px">
                             <n-descriptions-item label="生命值">
-                                {{ dungeonState.combatManager.enemy.currentHealth.toFixed(1) }} /
-                                {{ dungeonState.combatManager.enemy.stats.maxHealth.toFixed(1) }}
+                                {{ formatNumberToChineseUnit(dungeonState.combatManager.enemy.currentHealth) }} /
+                                {{ formatNumberToChineseUnit(dungeonState.combatManager.enemy.stats.maxHealth) }}
                             </n-descriptions-item>
                             <n-descriptions-item label="攻击力">
-                                {{ dungeonState.combatManager.enemy.stats.damage.toFixed(1) }}
+                                {{ formatNumberToChineseUnit(dungeonState.combatManager.enemy.stats.damage) }}
                             </n-descriptions-item>
                             <n-descriptions-item label="防御力">
-                                {{ dungeonState.combatManager.enemy.stats.defense.toFixed(1) }}
+                                {{ formatNumberToChineseUnit(dungeonState.combatManager.enemy.stats.defense) }}
                             </n-descriptions-item>
                             <n-descriptions-item label="速度">
-                                {{ dungeonState.combatManager.enemy.stats.speed.toFixed(1) }}
+                                {{ formatNumberToChineseUnit(dungeonState.combatManager.enemy.stats.speed) }}
                             </n-descriptions-item>
                         </n-descriptions>
                         <n-collapse style="margin-top: 16px">

--- a/src/views/Gacha.vue
+++ b/src/views/Gacha.vue
@@ -3,6 +3,7 @@ import { usePlayerStore } from '../stores/player'
 import { ref } from 'vue'
 import { useMessage } from 'naive-ui'
 import { InformationCircleOutline } from '@vicons/ionicons5'
+import { formatNumberToChineseUnit } from '../plugins/utils'
 
 const playerStore = usePlayerStore()
 const message = useMessage()
@@ -594,7 +595,7 @@ const types = {
                         </n-radio-group>
                     </div>
                     <div class="spirit-stones">
-                        <n-statistic label="灵石" :value="playerStore.spiritStones" />
+                        <n-statistic label="灵石" :value=" formatNumberToChineseUnit(playerStore.spiritStones)" />
                     </div>
                     <div class="gacha-item-container">
                         <div class="gacha-item" :class="{


### PR DESCRIPTION
数值单位显示/灵宠一键放生品质选择

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

此 pull request 引入了两个主要功能：它使用中文单位格式化数值，以提高可读性；并添加了批量宠物放生功能，可以选择品质。它还将选择的用于批量放生的宠物稀有度保存在本地存储中。

新功能：
- 增加了一个基于所选稀有度等级批量放生宠物的功能，允许玩家更有效地清理不需要的宠物。

增强功能：
- 通过使用中文单位（万、亿、兆等）格式化游戏中的数值显示，从而提高可读性并改善玩家体验。
- 将选择的用于批量放生的宠物稀有度保存在本地存储中，以便玩家不必每次都重新选择。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request introduces two main features: it formats numerical values with Chinese units for better readability and adds a batch pet release feature with quality selection. It also persists the selected pet rarities for batch release in local storage.

New Features:
- Adds a feature to batch release pets based on selected rarity tiers, allowing players to clear out unwanted pets more efficiently.

Enhancements:
- Improves the display of numerical values throughout the game by formatting them with Chinese units (万, 亿, 兆, etc.), enhancing readability and player experience.
- Persists the selected pet rarities for batch release in local storage, so that players don't have to re-select them every time.

</details>